### PR TITLE
カメラの移動によってオブジェクトが切れて見えないようになるのを修正

### DIFF
--- a/Assets/Scenes/Stage2.unity
+++ b/Assets/Scenes/Stage2.unity
@@ -3197,10 +3197,10 @@ MonoBehaviour:
   target1: {fileID: 132440699}
   target2: {fileID: 556853641}
   minSize: 5
-  maxSize: 15
+  maxSize: 20
   zoomSpeed: 5
   padding: 2
-  initialOffset: {x: 5, y: 7, z: 5}
+  initialOffset: {x: 9, y: 10, z: 9}
 --- !u!1001 &1007355481
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Stage3.unity
+++ b/Assets/Scenes/Stage3.unity
@@ -3180,10 +3180,10 @@ MonoBehaviour:
   target1: {fileID: 132440699}
   target2: {fileID: 556853641}
   minSize: 5
-  maxSize: 15
+  maxSize: 20
   zoomSpeed: 5
   padding: 2
-  initialOffset: {x: 5, y: 7, z: 5}
+  initialOffset: {x: 9, y: 10, z: 9}
 --- !u!1001 &1007355481
 PrefabInstance:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
CastomCameraControllerのInitialOfsetを変更することで修正した。